### PR TITLE
Trinity, formatting for Status Line

### DIFF
--- a/bureaucracy/docs/README.md
+++ b/bureaucracy/docs/README.md
@@ -1,5 +1,32 @@
 # Bureaucracy
 
+## About *Bureaucracy* for Status Line
+Bureaucracy tries to do many unusual things with screen layout to simulate various in-game world objects
+1. paper forms
+ - registration form at the beginning of the game
+ - withdrawal/deposit slips at the bank
+1. signage
+ - trademark info about the Boysenberry company
+ - in-taxi sign
+ - notice of airline closure at the airport
+ - hacker billboard at Persecution Complex
+4. software for the "Boysenberry" computer
+ - Dork 1
+ - Eclipse Predictor
+ - Recipes
+ - "unlabelled" cartridge
+ - CH/A0S
+
+Other games do interesting layouts using screen 1 (the "upper" screen, with the status bar) for similar signage (the "quote boxes" in Trinity). For example, Trinity does check for a narrow screen and disallows playing, however the internal calculations for displaying unusual layouts are not hard-coded to any set values. Trinity properly evaluates a screen mid-point based on the screen size the interpreter reports. In-game signage does include hard-coded spacing which assumes a wide screen, but again the layout engine itself doesn't care about that. It will do its best to center a sign (for example) regardless. After re-spacing the in-game text, Trinity's layout engine appears to work as expected, even on a small screen.
+
+**Not so with *Bureaucracy*!**
+
+Bureaucracy makes a huge number of grand assumptions about screen width in characters, hard-codes in sizing values, uses fixed strings of 40 spaces (rather than its own <PRINT-SPACES> routine), and so on. Additionally, some very complex code occurs in `mumble.zil` which drives the endgame PRINT puzzle on the Boysenberry. That particular code is very fragile and needs a particular arrangement of in-game variables like WIDTH, HEIGHT, COMPUTER-WIDTH, COMPUTER-HEIGHT, COMPUTER-REAL-WIDTH, and COMPUTER-REAL-HEIGHT, whose interplay remains a bit of a mystery to me even now.
+
+For the current release of Bureaucracy for Status Line I have tried to identify all of the values that need adjustment to make this game work on a 32-character wide screen. These values should also work for a 40-character screen (the C64, for example) but may not look quite as pixel-perfect. It is going to take quite a bit of effort to generalize these changes into a universal format that functions across all devices of any given width/height. The PRINT puzzle may yet exclude certain classes of device (GameBoy, for example?)
+
+## About the r160 Source Code
+  
 ## The Game
 
 Bureaucracy is a 1987 interactive fiction game written by Douglas Adams and published by Infocom.

--- a/bureaucracy/docs/README.md
+++ b/bureaucracy/docs/README.md
@@ -2,20 +2,22 @@
 
 ## About *Bureaucracy* for Status Line
 Bureaucracy tries to do many unusual things with screen layout to simulate various in-game world objects
+
 1. paper forms
- - registration form at the beginning of the game
- - withdrawal/deposit slips at the bank
+   - registration form at the beginning of the game
+   - withdrawal/deposit slips at the bank
+
 1. signage
- - trademark info about the Boysenberry company
- - in-taxi sign
- - notice of airline closure at the airport
- - hacker billboard at Persecution Complex
+   - trademark info about the Boysenberry company
+   - in-taxi sign
+   - notice of airline closure at the airport
+   - hacker billboard at Persecution Complex
 4. software for the "Boysenberry" computer
- - Dork 1
- - Eclipse Predictor
- - Recipes
- - "unlabelled" cartridge
- - CH/A0S
+   - Dork 1
+   - Eclipse Predictor
+   - Recipes
+   - "unlabelled" cartridge
+   - CH/A0S
 
 Other games do interesting layouts using screen 1 (the "upper" screen, with the status bar) for similar signage (the "quote boxes" in Trinity). For example, Trinity does check for a narrow screen and disallows playing, however the internal calculations for displaying unusual layouts are not hard-coded to any set values. Trinity properly evaluates a screen mid-point based on the screen size the interpreter reports. In-game signage does include hard-coded spacing which assumes a wide screen, but again the layout engine itself doesn't care about that. It will do its best to center a sign (for example) regardless. After re-spacing the in-game text, Trinity's layout engine appears to work as expected, even on a small screen.
 

--- a/bureaucracy/forms.zil
+++ b/bureaucracy/forms.zil
@@ -74,32 +74,32 @@
 
 ; "Messages should be 27 characters max"
 <BUILD-FORM LICENSE-FORM
-            (LAST-NAME "Last name" 17 "Chomper" FF-NAME
+            (LAST-NAME "Last name" 19 "Chomper" FF-NAME
 	     <PLTABLE "how embarrassing for you"
 		      "well-known criminal family">)
-	    (FIRST-NAME "First name" 17 "Random" FF-NAME
+	    (FIRST-NAME "First name" 18 "Random" FF-NAME
 	     <PLTABLE "parents had the last laugh">)
 	    (MIDDLE-INITIAL "Middle initial" 1 "Q" FF-MIDDLE-INITIAL)
 	    (YOUR-SEX "Your sex (M/F)" 1 "M" FF-SEX)
 	    (STREET-NUMBER "House number" 4 "69"
 			   FF-STREET-NUMBER
 			   <PLTABLE "due to be condemned">)
-	    (STREET-NAME "street name" 16 "Mandalay"
+	    (STREET-NAME "street name" 17 "Mandalay"
 	     <PLTABLE "the bad part of town"
 		      "wext to the dump">)
-	    (CITY-NAME "City" 15 "Newton" <PLTABLE "what a dump"
+	    (CITY-NAME "City" 18 "Newton" <PLTABLE "what a dump"
 						    "what a pit"
 						    "you'd better move again">)
-	    (STATE-NAME "State" 14 "MA" FF-STATE)
+	    (STATE-NAME "State" 5 "MA" FF-STATE)
 	    (ZIP-CODE "Zip" 6 "02174")
 	    (PHONE-NUMBER "Phone" 12 "646 9105" FF-PHONE-NUMBER)
-	    (EMPLOYER-NAME "2nd-to-last employer" 9 "Infocom"
+	    (EMPLOYER-NAME "2nd-to-last employer" 8 "Infocom"
 			   <PLTABLE "now in Chapter 11"
 				    "now in liquidation"
 				    "a sweatshop"
 				    "run by Bozo the Clown"
 				    "much happier without you">)
-	    (LEAST-FAVORITE-COLOR "Least liked colour" 6 "red"
+	    (LEAST-FAVORITE-COLOR "Least liked colour" 10 "red"
 	     FF-LEAST-FAVORITE-COLOR)
 	    (FRIEND "Girl/boy friend" 11 "Dunbar"
 		    <PLTABLE "what a dog"
@@ -129,7 +129,7 @@
 	 <COND (<T? .NOTE?>
 		<TELL "* ">)
 	       (T
-		<TELL "err: ">)>
+		<TELL "err:">)>
 	 <TELL .STR >  ; "no extraneous characters; keep it terse"
 	 <HLIGHT ,H-NORMAL>
 	 <COND (,FORM-COMPUTER? <HLIGHT ,H-INVERSE>)>

--- a/bureaucracy/verbs.zil
+++ b/bureaucracy/verbs.zil
@@ -522,8 +522,7 @@
 
 <DEFINE RELEASE ("AUX" V)
 	 <SET V <BAND <LOWCORE ZORKID> *3777*>>
-	 <TELL "Release " N .V>
-	 <DEBUGGING-CODE <TELL  " for Status Line on the Pico-8">>
+	 <TELL "Release " N .V " for Status Line on the Pico-8">
 	 T>
 
 <DEFINE COPYRIGHT ()

--- a/bureaucracy/verbs.zil
+++ b/bureaucracy/verbs.zil
@@ -522,7 +522,8 @@
 
 <DEFINE RELEASE ("AUX" V)
 	 <SET V <BAND <LOWCORE ZORKID> *3777*>>
-	 <TELL "Release " N .V " for Status Line on the Pico-8">
+	 <TELL "Release " N .V>
+	 <DEBUGGING-CODE <TELL  "(r160) for Status Line on the Pico-8">>
 	 T>
 
 <DEFINE COPYRIGHT ()

--- a/trinity/events.zil
+++ b/trinity/events.zil
@@ -203,15 +203,16 @@ A gentle voice whispers in your ear. ">
 	 <FINISH>
 	 <RTRUE>>
 
-
 <ROUTINE V-$PRAMS ("AUX" X)
 	 <CLEAR -1>
 	 <SPLIT 13>
 	 <SCREEN ,S-WINDOW>
 	 <BUFOUT <>>
-	 <CURSET 11 <- ,MIDSCREEN 21>>
 	 <HLIGHT ,H-BOLD>
-	 <TELL ,ALLPRAMS>
+	 <CURSET 11 4>
+	 <TELL "All prams lead to the">
+	 <CURSET 12 4>
+	 <TELL " Kensington Gardens.">
 	 <HLIGHT ,H-NORMAL>
 	 <SCREEN ,S-TEXT>
 	 <SET X <INPUT 1>>

--- a/trinity/misc.zil
+++ b/trinity/misc.zil
@@ -72,7 +72,7 @@
 <ROUTINE GO ()
 	 <SETG MIDSCREEN </ <GETB 0 33> 2>>
 	 <INC MIDSCREEN>
-	 <COND (<L? ,MIDSCREEN 32>
+	 <COND (<L? ,MIDSCREEN 16>
 		<CRLF>
 		<TOO-NARROW>
 		<QUIT>)>
@@ -1750,18 +1750,15 @@
  If [left-margin] is not specified, window is centered."
 
 <ROUTINE WINDOW (TABLE "OPTIONAL" (MARGIN 0)
-		       "AUX" (Y 4) (I 2) WIDTH LINES STR PLINES)
+		       "AUX" (Y 6) (I 2) WIDTH LINES STR PLINES)
 
 	 <SET LINES <GET .TABLE 0>>
 	 <SET PLINES .LINES>
-	 <SET WIDTH <GET .TABLE 1>>
-	 <COND ; (<G? .WIDTH <GETB 0 33>>
-		  <TELL "[Window too wide!]" CR>
-		  <RTRUE>)
-	       (<ZERO? .MARGIN>
-		<SET MARGIN <- ,MIDSCREEN </ .WIDTH 2>>>)> ; "Center"
+	 <SET WIDTH <GET .TABLE 1>> ;"printing always adds 2 spaces to a line so just add the 2 here and report the true table width"
+	 <SET MARGIN <- ,MIDSCREEN </ .WIDTH 2>>> ; "ALWAYS center"
 
-	 <SPLIT <+ .LINES 4>> ; "Set up the window."
+	 ; "I think the Y value should drive the split?"
+	 <SPLIT <+ .LINES .Y>> ; "Set up the window."
 	 <SCREEN ,S-WINDOW>
 	 <BUFOUT <>>
 	 <HLIGHT ,H-INVERSE>

--- a/trinity/misc.zil
+++ b/trinity/misc.zil
@@ -440,7 +440,7 @@
 		<COND (<T? ,SUITED?>
 		       <TELL ", in a soap bubble">)
 		      (<T? ,IN-PRAM?>
-		       <TELL ", in the " D ,PRAM>)
+		       <TELL ", in the pram">)
 		      (<T? ,IN-DISH?>
 		       <TELL ", in the dish">)
 		      (<T? ,IN-DORY?>

--- a/trinity/people.zil
+++ b/trinity/people.zil
@@ -201,7 +201,7 @@ D ,BAG " and a " D ,SCOIN " for you." CR>
 <ROUTINE ASK-BWOMAN-ABOUT (OBJ "AUX" (Q <>) CNT TBL X V)
 	 <MAKE ,BWOMAN ,SEEN>
 	 <COND (<EQUAL? .OBJ ,GTRINITY ,PLUTONIUM>
-		<COND (<L? <GETB 0 33> 79>
+		<COND (<L? <GETB 0 33> 32>
 		       <TELL CTHE ,BWOMAN " just smiles." CR>
 		       <RTRUE>)>
 		<V-$CREDITS>

--- a/trinity/places.zil
+++ b/trinity/places.zil
@@ -6689,86 +6689,116 @@ D ,OPSHORE ,PERIOD>
 
 <GLOBAL QUOTES:TABLE
 	<PTABLE
-	 <PLTABLE 24
-		  "Time isn't holding us."
-	 	  "Time isn't after us.   "
-	 	  "Same as it ever was,  "
-	 	  "Same as it ever was.   "
-	 	  0
-	 	  "        -- David Byrne">
-	 <PLTABLE 44
-		  "They are of sick and diseased imaginations"
-	 	  "who would toll the world's knell so soon. "
-	 	  0
-	 	  "                    -- Henry David Thoreau">
-	 <PLTABLE 42
-	 	  "Atoms or systems into ruin hurled,      "
-	 	  "And now a bubble burst, and now a world."
-	 	  0
-	 	  "                       -- Alexander Pope">
-	 <PLTABLE 42
-	 	  "\"And 'the wabe' is the grass-plot round "
-	 	  " a sun-dial, I suppose?\" said Alice,    "
-		  " surprised at her own ingenuity.         "
-	 	  0
-	 	  "\"Of course it is. It's called 'wabe,'   "
-	 	  " you know, because it goes a long way   "
-	 	  " before it, and a long way behind it --\""
-	 	  0
-	 	  "                        -- Lewis Carroll">
-	 <PLTABLE 22
-	 	  "Any sufficiently    "
-	 	  "advanced technology "
-	 	  "is indistinguishable"
-	 	  "from magic.          "
-	 	  0
-	 	  " -- Arthur C. Clarke">
-	 <PLTABLE 22
-		  " Any sufficiently   "
-		  " arcane magic is    "
-		  " indistinguishable  "
-		  " from technology.    "
-		  0
-		  " -- P. David Lebling">
-	 <PLTABLE 40
-		  "The love of posterity is a consequence"
-	 	  "of the necessity of death. If a man   "
-	 	  "were sure of living forever, he would "
-	 	  "not care about his offspring.          "
-	 	  0
-	 	  "                -- Nathaniel Hawthorne">
-	 <PLTABLE 37
-	 	  "Could annihilation occur in matter,"
-	 	  "this were the thing to do it.       "
-	 	  0
-	 	  "                 -- Herman Melville">
-	 <PLTABLE 44
-	 	  "From this crude lab that spawned a dud,   "
-	 	  "Their necks to Truman's axe uncurled,     "
-	 	  "Lo, the embattled savants stood           "
-	 	  "And fired the flop heard 'round the world."
-	 	  0
-	 	  "           -- Los Alamos ditty, circa 1945">
-	 <PLTABLE 26
-	  	  " Can ye not discern the "
-		  " signs of the times?    "
-		  0
-		  "        -- Matthew 16:3 ">
-	 <PLTABLE 20
-	  	  "Il y a une horloge"
-		  "qui ne sonne pas. "
-		  0
-		  " -- Arthur Rimbaud">
-	 <PLTABLE 40
-		  "'Twere better Charity                 "
-		  "To leave me in the Atom's Tomb -      "
-		  "Merry, and Nought, and gay, and numb -"
-		  "Than this smart Misery.                "
-		  0
-		  "                    -- Emily Dickinson">
-	 <PLTABLE 54
-		  "Distant and dead resuscitate,                       "
-		  "They show me as the dial or move as the hands of me,"
-		  "I am the clock myself.                               "
-		  0
-		  "                                     -- Walt Whitman">>>
+	<PLTABLE 24
+		"Time isn't holding us."
+		"Time isn't after us.   "
+		"Same as it ever was,  "
+		"Same as it ever was.   "
+		0
+		"         - David Byrne">
+
+	<PLTABLE 24
+		"They are of sick and  "
+		"diseased imaginations "
+		"who would toll the    "
+		"world's knell so soon."
+		0
+		" - Henry David Thoreau">
+
+	<PLTABLE 25
+		"Atoms or systems       "
+		"   into ruin hurl'd,   "
+		"And now a bubble burst,"
+		"   and now a world.     "
+		0
+		"       - Alexander Pope">
+
+	<PLTABLE 26
+		"\"And 'the wabe' is the  "
+		"grass-plot round a sun- "
+		"dial, I suppose?\" said  "
+		"Alice, surprised at her "
+		"own ingenuity.           "
+		0
+		"\"Of course it is. It's  "
+		"called 'wabe,' you know,"
+		"because it goes a long  "
+		"way before it, and a    "
+		"long way behind it --\"  "
+		0
+		"         - Lewis Carroll">
+
+	<PLTABLE 22
+		"Any sufficiently    "
+		"advanced technology "
+		"is indistinguishable"
+		"from magic.          "
+		0
+		"  - Arthur C. Clarke">
+	
+	<PLTABLE 22
+		"Any sufficiently    "
+		"arcane magic is     "
+		"indistinguishable   "
+		"from technology.     "
+		0
+		"  - P. David Lebling">
+
+	<PLTABLE 28
+		"The love of posterity is a"
+		"consequence of the neces- "
+		"sity of death. If a man   "
+		"were sure of living       "
+		"forever, he would not     "
+		"care about his offspring.  "
+		0
+		"     - Nathaniel Hawthorne">
+
+	<PLTABLE 26
+		"Could annihilation occur"
+		"in matter, this were the"
+		"thing to do it.          "
+		0
+		"       - Herman Melville">
+
+	<PLTABLE 26
+		"From this crude lab that"
+		"spawned a dud,          "
+		"Their necks to Truman's "
+		"axe uncurled,           "
+		"Lo, the embattled       "
+		"savants stood           "
+		"And fired the flop      "
+		"heard 'round the world.  "
+		0
+		"      - Los Alamos ditty"
+		"              circa 1945">
+
+	<PLTABLE 25
+		"Can ye not discern the "
+		"signs of the times?    "
+		0
+		"         - Matthew 16:3">
+
+	<PLTABLE 20
+		"Il y a une horloge"
+		"qui ne sonne pas.  "
+		0
+		"  - Arthur Rimbaud">
+
+	<PLTABLE 32
+		"'Twere better Charity           "
+		"To leave me in the Atom's Tomb -"
+		"Merry, and Nought,              "
+		"   and gay, and numb -          "
+		"Than this smart Misery.          "
+		0
+		"             - Emily Dickinson">
+
+	<PLTABLE 32
+		"Distant and dead resuscitate, "
+		"They show me as the dial or   "
+		"move as the hands of me,      "
+		"I am the clock myself.         "
+		0
+		"                - Walt Whitman">>>

--- a/trinity/things.zil
+++ b/trinity/things.zil
@@ -17146,7 +17146,7 @@ D ,HOPENING "s, " D ,WINDOWS
 
 <ROUTINE RELEASE ("AUX" V)
 	 <SET V <BAND <GET 0 1> *3777*>>
-	 <TELL "Release " N .V ; " for Internal Testing" >
+	 <TELL "Release " N .V  "(r15) for Status Line on the Pico-8" >
 	 <RTRUE>>
 
 <OBJECT BIKES

--- a/trinity/things.zil
+++ b/trinity/things.zil
@@ -18536,73 +18536,94 @@ D ,MIKE " in the " D ,SCHOOL " to some remote part of the " D ,LAGOON ,PERIOD>
 	 <RTRUE>>
 
 <ROUTINE V-$CREDITS ("AUX" X)
-	 <COND (<L? <GETB 0 33> 79>
+	 <COND (<L? <GETB 0 33> 32>
 		<TOO-NARROW>
 		<RTRUE>)>
 	 <CLEAR -1>
-	 <SPLIT 23>
+	 <SPLIT 21>
 	 <SCREEN ,S-WINDOW>
 	 <BUFOUT <>>
 
 	 <CURSET 2 5>
 	 <BIG-TRINITY> ; "95px wide"
 	 <HLIGHT ,H-NORMAL>
-	 <CURSET 3 32>
-	 <TELL "by Brian Moriarty">
+	 <CURSET 3 8>
+	 <TELL "by brian moriarty">
 
-	 <CURSET 5 37>
-	 <TELL "Testing">
+	 <CURSET 5 4>
+	 <TELL "        Testing">
 	 <CURSET 6 4>
-	 <TELL
-"Gary Brennan    Amy Briggs    Suzanne Frank    Max Buxton    Liz Cyr-Jones">
-
-	 <CURSET 8 13>
+	 <TELL "Gary Brennan   Amy Briggs">
+	 <CURSET 7 4>
+	 <TELL "Suzanne Frank  Max Buxton">
+	 <CURSET 8 4>
+	 <TELL "      Liz Cyr-Jones">
+	 <CURSET 10 11>
 	 <TELL "Packaging">
-	 <CURSET 8 33>
-	 <TELL "Project Manager">
-	 <CURSET 8 58>
-	 <TELL "Copywriter">
-
-	 <CURSET 9 10>
+	 <CURSET 11 8>
 	 <TELL "Carl Genatossio">
-	 <CURSET 9 35>
+	 <CURSET 13 8>
+	 <TELL "Project Manager">
+	 <CURSET 14 11>
 	 <TELL "Jon Palace">
-	 <CURSET 9 55>
+	 <CURSET 16 11>
+	 <TELL "Copywriter">
+	 <CURSET 17 8>
 	 <TELL "Elizabeth Langosy">
+	 <CURSET 21 4>
+	 <TELL "~ any key for next page ~">
 
-	 <CURSET 11 12>
+	 ; "page the credits"
+	 <SET X <INPUT 1>>
+	 <CLEAR 1>
+
+	 <CURSET 2 10>
 	 <TELL "Illustrator">
-	 <CURSET 11 35>
-	 <TELL "Photography">
-	 <CURSET 11 58>
-	 <TELL "Inner Cover">
-
-	 <CURSET 12 11>
+	 <CURSET 3 9>
 	 <TELL "Richard Howell">
-	 <CURSET 12 35>
-	 <TELL "Steve Grohe">
-	 <CURSET 12 56>
-	 <TELL "Charles Freeman">
-
-	 <CURSET 14 14>
+	 <CURSET 5 2>
+	 <TELL "Photography      Inner Cover">
+	 <CURSET 6 2>
+	 <TELL "Steve Grohe    Charles Freeman">
+	 <CURSET 8 12>
 	 <TELL "Sundial">
-	 <CURSET 14 35>
+	 <CURSET 9 8>
+	 <TELL "Geoff Hodgkinson">
+	 <CURSET 11 10>
 	 <TELL "Map & Crane">
-	 <CURSET 14 53>
+	 <CURSET 12 7>
+	 <TELL "Meredith Lightbown">
+	 <CURSET 14 5>
 	 <TELL "Production Coordinator">
+	 <CURSET 15 10>
+	 <TELL "Angela Raup">
+	 <CURSET 21 4>
+	 <TELL "~ any key for next page ~">
 
-	 <CURSET 15 9>
-	 <TELL "Geoff Hodgkinson       Meredith Lightbown        Angela Raup">
-	 <CURSET 17 28>
+	 ; "page the credits"
+	 <SET X <INPUT 1>>
+	 <CLEAR 1>
+
+	 <CURSET 2 3>
 	 <TELL "Microcomputer Interpreters">
-	 <CURSET 18 19>
-	 <TELL "Duncan Blanchard    Ed Black    Linde Simpson">
-	 <CURSET 19 12>
-	 <TELL "Andy Kaluzniacki    Paul Gross    Mike Morton    Richard Lay">
-	 <CURSET 21 18>
-	 <TELL "Interactive Fiction Plus(TM) Development System">
-	 <CURSET 22 21>
-	 <TELL "Marc Blank    Dave Lebling    Stu Galley">
+	 <CURSET 3 3>
+	 <TELL "Duncan Blanchard  Ed Black">
+	 <CURSET 4 1>
+	 <TELL "Linde Simpson  Duncan Blanchard">
+	 <CURSET 5 2>
+	 <TELL "Andy Kaluzniacki  Paul Gross">
+	 <CURSET 6 4>
+	 <TELL "Mike Morton  Richard Lay">
+	 <CURSET 8 2>
+	 <TELL " Interactive Fiction Plus(TM)">
+	 <CURSET 9 2>
+	 <TELL "     Development System">
+	 <CURSET 10 2>
+	 <TELL "  Marc Blank  Dave Lebling">
+	 <CURSET 11 2>
+	 <TELL "         Stu Galley">
+	 <CURSET 21 2>
+	 <TELL "~ any key to return to game ~">
 	 <SCREEN ,S-TEXT>
 	 <SET X <INPUT 1>>
          <V-$REFRESH>
@@ -18611,7 +18632,7 @@ D ,MIKE " in the " D ,SCHOOL " to some remote part of the " D ,LAGOON ,PERIOD>
 
 <ROUTINE BIG-TRINITY ()
 	 <HLIGHT ,H-BOLD>
-	 <TELL "T    R    I    N    I    T    Y">
+	 <TELL "T  R  I  N  I  T  Y">
 	 <RTRUE>>
 
 <OBJECT PLUTONIUM

--- a/trinity/things.zil
+++ b/trinity/things.zil
@@ -3562,17 +3562,22 @@ D ,PARASOL ", you bravely close your eyes and pinch your nose shut" ,PCR>
 		<ST-QUOTE>)>
 	 <CARRIAGE-RETURNS>
 	 <CLEAR -1>
-	 <SPLIT 14>
+	 <SPLIT 16>
 	 <SCREEN ,S-WINDOW>
 	 <BUFOUT <>>
-	 <CURSET 10 25>
-	 <BIG-TRINITY>
-	 <CURSET 12 29>
+	 <CURSET 3 5>
+	 <BIG-TRINITY> ; "95px wide"
+	 <CURSET 12 6>
 	 <FANTASY>
-	 <CURSET 13 15>
-	 <COPYRIGHT>
-	 <CURSET 14 21>
-	 <TRADEMARK>
+	 <CURSET 13 2>
+	 <TELL "Copyright (C)1986 Infocom, Inc.">
+	 <CURSET 14 8>
+	 <TELL "All rights reserved.">
+	 <CURSET 15 6>
+	 <ITALICIZE "Trinity">
+	 <TELL " is a trademark">
+	 <CURSET 16 9>
+	 <TELL "of Infocom, Inc.">
 	 <SCREEN ,S-TEXT>
 	 <SET X <INPUT 1>>
          <V-$REFRESH>

--- a/trinity/things.zil
+++ b/trinity/things.zil
@@ -18544,8 +18544,8 @@ D ,MIKE " in the " D ,SCHOOL " to some remote part of the " D ,LAGOON ,PERIOD>
 	 <SCREEN ,S-WINDOW>
 	 <BUFOUT <>>
 
-	 <CURSET 2 25>
-	 <BIG-TRINITY>
+	 <CURSET 2 5>
+	 <BIG-TRINITY> ; "95px wide"
 	 <HLIGHT ,H-NORMAL>
 	 <CURSET 3 32>
 	 <TELL "by Brian Moriarty">


### PR DESCRIPTION
First major update to Trinity layouts to make them work on the small screen of Status Line. Mostly involved making the interstitial quote boxes format and center on screen, but I also enabled the credits screen on `ask woman about trinity` because, why not?
![trinity_quote](https://user-images.githubusercontent.com/320377/159103781-0952846a-1509-4315-b5a9-cb988c915e71.png)

![trinity_credits](https://user-images.githubusercontent.com/320377/159103782-5f3a4240-98d4-423c-abd2-f153125ff980.png)
